### PR TITLE
New search modal

### DIFF
--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -44,7 +44,7 @@
         <?js if (this.navOptions.search) { ?>
             <div class="col-sm-3 col-md-3">
                 <form class="navbar-form" role="search" id="apryse-search-modal">
-										<i class="glyphicon fake-btn glyphicon-search"></i>
+										<i class="glyphicon fake-btn glyphicon-search" style="cursor:pointer"></i>
                 </form>
             </div>
         <?js } ?>

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -245,7 +245,7 @@ $( function () {
 
 <script type="text/javascript">
 	window.apryseSearch.loadSearchTool({
-		targetSelector: '[role='search'] .input-group',
+		targetSelector: "[role='search'] .input-group",
 		searchConfig: {},
 	});
 </script>

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -18,8 +18,7 @@
 </head>
 
 <body>
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5FFX2TF"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5FFX2TF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="navbar navbar-default navbar-fixed-top <?js= this.navOptions.inverseNav ? 'navbar-inverse' : '' ?>">
 <div class="container">
 	<div class="navbar-header"><img className="navbar-img" src="img/logo-white.png" width="40" height="40"/>

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -241,15 +241,13 @@ $( function () {
     </script>
 <?js } ?>
 
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+<script crossorigin src="https://prod.global-search.apryse.com/apryse-search.umd.js"></script>
+
 <script type="text/javascript">
-docsearch({
-	appId: "3MUCVV1SU4",
-	apiKey: "1b3d775fc5e723b367372f967661c103",
-	indexName: "apryse",
-	container: "[role='search'] .input-group",
-	debug: false
-});
+	window.apryseSearch.loadSearchTool({
+		targetSelector: '[role='search'] .input-group',
+		searchConfig: {},
+	});
 </script>
 </body>
 </html>

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -241,7 +241,24 @@ $( function () {
 <script type="text/javascript">
 	window.apryseSearch.loadSearchTool({
 		targetSelector: "#apryse-search-modal",
-		searchConfig: {},
+		searchConfig: {
+			defaultProduct: "web",
+			tabs: [
+				{
+					name: "API",
+					filters: [
+							{ attribute: 'language', title: 'Language', default: 'javascript' },
+							{ attribute: 'product', title: 'Product' },
+					]
+				},
+				{
+					name: "Guides"
+				},
+				{
+					name: "Forum posts"
+				}
+			]
+		},
 	});
 </script>
 </body>

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -18,7 +18,8 @@
 </head>
 
 <body>
-
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5FFX2TF"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="navbar navbar-default navbar-fixed-top <?js= this.navOptions.inverseNav ? 'navbar-inverse' : '' ?>">
 <div class="container">
 	<div class="navbar-header"><img className="navbar-img" src="img/logo-white.png" width="40" height="40"/>

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -248,7 +248,7 @@ $( function () {
 					name: "API",
 					filters: [
 							{ attribute: 'language', title: 'Language', default: 'JavaScript' },
-							{ attribute: 'product', title: 'Product', default: 'web' },
+							{ attribute: 'product', title: 'Product', default: 'WebViewer SDK' },
 					]
 				},
 				{

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -236,6 +236,9 @@ $( function () {
     </script>
 <?js } ?>
 
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
 <script crossorigin src="https://prod.global-search.apryse.com/apryse-search.umd.js"></script>
 
 <script type="text/javascript">

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -43,13 +43,8 @@
 		</ul>
         <?js if (this.navOptions.search) { ?>
             <div class="col-sm-3 col-md-3">
-                <form class="navbar-form" role="search">
-                    <div class="input-group">	
-											<input type="text" class="form-control" placeholder="Search" name="q" id="search-input">
-											<!-- <div class="input-group-btn-search"> -->
-												<!-- </div> -->
-											</div>
-											<i class="glyphicon fake-btn glyphicon-search"></i>
+                <form class="navbar-form" role="search" id="apryse-search-modal">
+										<i class="glyphicon fake-btn glyphicon-search"></i>
                 </form>
             </div>
         <?js } ?>
@@ -245,7 +240,7 @@ $( function () {
 
 <script type="text/javascript">
 	window.apryseSearch.loadSearchTool({
-		targetSelector: "[role='search'] .input-group",
+		targetSelector: "#apryse-search-modal",
 		searchConfig: {},
 	});
 </script>

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -236,9 +236,6 @@ $( function () {
     </script>
 <?js } ?>
 
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
 <script crossorigin src="https://prod.global-search.apryse.com/apryse-search.umd.js"></script>
 
 <script type="text/javascript">

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -236,7 +236,7 @@ $( function () {
     </script>
 <?js } ?>
 
-<script crossorigin src="https://prod.global-search.apryse.com/apryse-search.umd.js"></script>
+<script src="https://prod.global-search.apryse.com/apryse-search.umd.js"></script>
 
 <script type="text/javascript">
 	window.apryseSearch.loadSearchTool({

--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -247,8 +247,8 @@ $( function () {
 				{
 					name: "API",
 					filters: [
-							{ attribute: 'language', title: 'Language', default: 'javascript' },
-							{ attribute: 'product', title: 'Product' },
+							{ attribute: 'language', title: 'Language', default: 'JavaScript' },
+							{ attribute: 'product', title: 'Product', default: 'web' },
 					]
 				},
 				{

--- a/template-algolia/tmpl/quicksearch.tmpl
+++ b/template-algolia/tmpl/quicksearch.tmpl
@@ -1,31 +1,5 @@
 <html>
 <head>
 </head>
-<body style="background: transparent;">
-    <script src="scripts/docstrap.lib.js"></script>
-    <script src="scripts/lunr.min.js"></script>
-    <script src="scripts/fulltext-search.js"></script>
 
-    <script type="text/x-docstrap-searchdb">
-    <%= searchableDocuments %>
-    </script>
-
-    <script type="text/javascript">
-        $(document).ready(function() {
-            Searcher.init();
-        });
-
-        $(window).on("message", function(msg) {
-            var msgData = msg.originalEvent.data;
-
-            if (msgData.msgid != "docstrap.quicksearch.start") {
-                return;
-            }
-
-            var results = Searcher.search(msgData.searchTerms);
-
-            window.parent.postMessage({"results": results, "msgid": "docstrap.quicksearch.done"}, "*");
-        });
-    </script>
-</body>
 </html>


### PR DESCRIPTION
Adds new search modal to API Search.

To verify:
- In the WebViewer repo, find the file `jsdoc/package.json`
- Update the `ink-docstrap` dependency to `PDFTron/docstrap#feat/new-search`
- Delete `jsdoc/package-lock.json`
- Run `npm run generate-docs-live`

Note: On sdk.apryse.com, the search results won't open in a new tab like they do locally.

Now open one of the HTML files generated by the build, and then click the search button. You should see the new search modal open up with WebViewer set as the default product. 

![image](https://github.com/user-attachments/assets/2a7559fd-c00f-4921-9992-3fe1d735b211)
